### PR TITLE
Added private field to parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ With Charlie's hard work finished, let's watch which ZoKrates commands Alice, th
 
 She first computes her witness:
 
-    $ ./target/release/zokrates compute-witness -a 5
+    $ ./target/release/zokrates compute-witness -a 5 --interactive
 
 *(ZoKrates is currently specified so that public arguments are passed following the `-a` flag but private arguments are passed interactively afterwards. Again ZoKrates is a WIP and may change in the future)*. Alice then passes ZoKrates her private values `3` and `7` after being prompted. Zokrates then creates a file called `witness` containing the public and private values making up the witness. Alice grab's the publically available `proving.key` file from Charlie and generates her proof.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ First let's watch which ZoKrates commands Charlie, the trusted party, runs. Char
 Charlie's program looks something like this, and assuming we are in the ZoKrates root directory, he saves it to a file called 
 `sumsToFifteen.code`.
 
-    def main(x):
+    def main(x, private s1, private s2):
 	    s1 + s2 + x == 15
 	    return 1
 


### PR DESCRIPTION
It looks like the compilation fails when I try to compile the program:
```
def main(x):
     s1 + s2 + x == 15
     return 1
```

I got:
```
Compiling sumsToFifteen.code
thread 'main' panicked at 'Compilation failed: Semantic error: s1 is undefined', src/main.rs:208:29
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

Based on what I have seen here: https://github.com/JacobEberhardt/ZoKrates/blob/master/examples/factorization.code
We can now add private parameters as arguments.
Doing so in the `sumsToFifteen.code` solved my problem and compiled the code to `out.code` as expected.